### PR TITLE
(Makefile) Fix generation of index files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 #   make clean
 #       Deletes all the .index and .index-dir files
 
-SUBDIRS = $(shell ls */ -d --escape)
+SUBDIRS = $(shell ls */ -d --escape | sed 's/\x27/\\\x27/g')
 
 all: clean
 	@echo "" > .index


### PR DESCRIPTION
PR #29 broke generation of content index files by adding a directory with single quotes in its name (which the current Makefile cannot handle). This prevents the repo contents from being uploaded to the buildbot.

This PR fixes the issue.